### PR TITLE
Feature/temperature

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -235,12 +235,20 @@ In addition to a project settings file, a project's `.gemini` directory can cont
     }
     ```
 
+- **`temperature`** (number):
+  - **Description:** Controls the randomness of the model's responses. Lower values (closer to 0.0) make responses more deterministic and focused, while higher values (closer to 2.0) make responses more creative and varied. This parameter affects how the model selects tokens during generation.
+  - **Range:** 0.0 to 2.0
+  - **Default:** 0.0 (most deterministic)
+  - **Example:** `"temperature": 0.7`
+  - **Note:** This setting can be overridden by the `--temperature` command-line argument.
+
 ### Example `settings.json`:
 
 ```json
 {
   "theme": "GitHub",
   "sandbox": "docker",
+  "temperature": 0.7,
   "toolDiscoveryCommand": "bin/get_tools",
   "toolCallCommand": "bin/call_tool",
   "mcpServers": {
@@ -342,6 +350,10 @@ Arguments passed directly when running the CLI can override other configurations
 - **`--model <model_name>`** (**`-m <model_name>`**):
   - Specifies the Gemini model to use for this session.
   - Example: `npm start -- --model gemini-1.5-pro-latest`
+- **`--temperature <value>`** (**`-t <value>`**):
+  - Sets the temperature parameter for this session, controlling response randomness.
+  - Range: 0.0 to 2.0 (lower values = more deterministic, higher values = more creative)
+  - Example: `npm start -- --temperature 0.7`
 - **`--prompt <your_prompt>`** (**`-p <your_prompt>`**):
   - Used to pass a prompt directly to the command. This invokes Gemini CLI in a non-interactive mode.
 - **`--sandbox`** (**`-s`**):

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -101,6 +101,9 @@ export interface Settings {
   // Add other settings here.
   ideMode?: boolean;
   memoryDiscoveryMaxDirs?: number;
+  
+  // Temperature for model generation (0.0-2.0, lower is more deterministic)
+  temperature?: number;
 }
 
 export interface SettingsError {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -312,4 +312,50 @@ describe('Server Config (config.ts)', () => {
       expect(config.getTelemetryOtlpEndpoint()).toBe(DEFAULT_OTLP_ENDPOINT);
     });
   });
+
+  describe('Temperature Settings', () => {
+    it('should return default temperature (0.0) if not provided', () => {
+      const params: ConfigParameters = {
+        ...baseParams,
+      };
+      const config = new Config(params);
+      expect(config.getTemperature()).toBe(0.0);
+    });
+
+    it('should return provided temperature value', () => {
+      const params: ConfigParameters = {
+        ...baseParams,
+        temperature: 1.5,
+      };
+      const config = new Config(params);
+      expect(config.getTemperature()).toBe(1.5);
+    });
+
+    it('should handle temperature value of 0.0', () => {
+      const params: ConfigParameters = {
+        ...baseParams,
+        temperature: 0.0,
+      };
+      const config = new Config(params);
+      expect(config.getTemperature()).toBe(0.0);
+    });
+
+    it('should handle temperature value of 2.0', () => {
+      const params: ConfigParameters = {
+        ...baseParams,
+        temperature: 2.0,
+      };
+      const config = new Config(params);
+      expect(config.getTemperature()).toBe(2.0);
+    });
+
+    it('should handle fractional temperature values', () => {
+      const params: ConfigParameters = {
+        ...baseParams,
+        temperature: 0.7,
+      };
+      const config = new Config(params);
+      expect(config.getTemperature()).toBe(0.7);
+    });
+  });
 });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -180,6 +180,7 @@ export interface ConfigParameters {
   noBrowser?: boolean;
   summarizeToolOutput?: Record<string, SummarizeToolOutputSettings>;
   ideMode?: boolean;
+  temperature?: number;
 }
 
 export class Config {
@@ -235,6 +236,7 @@ export class Config {
     | Record<string, SummarizeToolOutputSettings>
     | undefined;
   private readonly experimentalAcp: boolean = false;
+  private readonly temperature: number;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -286,6 +288,7 @@ export class Config {
     this.noBrowser = params.noBrowser ?? false;
     this.summarizeToolOutput = params.summarizeToolOutput;
     this.ideMode = params.ideMode ?? false;
+    this.temperature = params.temperature ?? 0.0;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -572,6 +575,10 @@ export class Config {
 
   getIdeMode(): boolean {
     return this.ideMode;
+  }
+
+  getTemperature(): number {
+    return this.temperature;
   }
 
   async getGitService(): Promise<GitService> {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -200,6 +200,7 @@ describe('Gemini Client (client.ts)', () => {
       getNoBrowser: vi.fn().mockReturnValue(false),
       getUsageStatisticsEnabled: vi.fn().mockReturnValue(true),
       getIdeMode: vi.fn().mockReturnValue(false),
+      getTemperature: vi.fn().mockReturnValue(0.0),
       getGeminiClient: vi.fn(),
     };
     const MockedConfig = vi.mocked(Config, true);
@@ -1094,6 +1095,206 @@ Here are files the user has recently opened, with the most recent at the top:
         fallbackModel,
         undefined,
       );
+    });
+  
+    describe('temperature configuration', () => {
+      it('should use temperature from config in generateContent', async () => {
+        const contents = [{ role: 'user', parts: [{ text: 'test' }] }];
+        const customTemperature = 1.5;
+        
+        // Create a new client with custom temperature in config
+        const fileService = new FileDiscoveryService('/test/dir');
+        const testContentGeneratorConfig = {
+          model: 'test-model',
+          apiKey: 'test-key',
+          vertexai: false,
+          authType: AuthType.USE_GEMINI,
+        };
+        
+        const customMockConfigObject = {
+          getContentGeneratorConfig: vi
+            .fn()
+            .mockReturnValue(testContentGeneratorConfig),
+          getToolRegistry: vi.fn().mockResolvedValue({
+            getFunctionDeclarations: vi.fn().mockReturnValue([]),
+            getTool: vi.fn().mockReturnValue(null),
+          }),
+          getModel: vi.fn().mockReturnValue('test-model'),
+          getEmbeddingModel: vi.fn().mockReturnValue('test-embedding-model'),
+          getApiKey: vi.fn().mockReturnValue('test-key'),
+          getVertexAI: vi.fn().mockReturnValue(false),
+          getUserAgent: vi.fn().mockReturnValue('test-agent'),
+          getUserMemory: vi.fn().mockReturnValue(''),
+          getFullContext: vi.fn().mockReturnValue(false),
+          getSessionId: vi.fn().mockReturnValue('test-session-id'),
+          getProxy: vi.fn().mockReturnValue(undefined),
+          getWorkingDir: vi.fn().mockReturnValue('/test/dir'),
+          getFileService: vi.fn().mockReturnValue(fileService),
+          getMaxSessionTurns: vi.fn().mockReturnValue(0),
+          getQuotaErrorOccurred: vi.fn().mockReturnValue(false),
+          setQuotaErrorOccurred: vi.fn(),
+          getNoBrowser: vi.fn().mockReturnValue(false),
+          getUsageStatisticsEnabled: vi.fn().mockReturnValue(true),
+          getIdeMode: vi.fn().mockReturnValue(false),
+          getTemperature: vi.fn().mockReturnValue(customTemperature),
+          getGeminiClient: vi.fn(),
+        };
+        
+        const CustomMockedConfig = vi.mocked(Config, true);
+        CustomMockedConfig.mockImplementation(
+          () => customMockConfigObject as unknown as Config,
+        );
+        
+        const customClient = new GeminiClient(new Config({} as never));
+        customMockConfigObject.getGeminiClient.mockReturnValue(customClient);
+        
+        await customClient.initialize(testContentGeneratorConfig);
+  
+        const mockGenerator: Partial<ContentGenerator> = {
+          countTokens: vi.fn().mockResolvedValue({ totalTokens: 1 }),
+          generateContent: mockGenerateContentFn,
+        };
+        customClient['contentGenerator'] = mockGenerator as ContentGenerator;
+  
+        await customClient.generateContent(contents, {}, new AbortController().signal);
+  
+        expect(mockGenerateContentFn).toHaveBeenCalledWith({
+          model: 'test-model',
+          config: {
+            abortSignal: expect.any(AbortSignal),
+            systemInstruction: getCoreSystemPrompt(''),
+            temperature: customTemperature,
+            topP: 1,
+          },
+          contents,
+        });
+      });
+  
+      it('should use default temperature (0.0) when not configured', async () => {
+        const contents = [{ role: 'user', parts: [{ text: 'test' }] }];
+        
+        // Mock config to return default temperature
+        vi.spyOn(client['config'], 'getTemperature').mockReturnValue(0.0);
+  
+        const mockGenerator: Partial<ContentGenerator> = {
+          countTokens: vi.fn().mockResolvedValue({ totalTokens: 1 }),
+          generateContent: mockGenerateContentFn,
+        };
+        client['contentGenerator'] = mockGenerator as ContentGenerator;
+  
+        await client.generateContent(contents, {}, new AbortController().signal);
+  
+        expect(mockGenerateContentFn).toHaveBeenCalledWith({
+          model: 'test-model',
+          config: {
+            abortSignal: expect.any(AbortSignal),
+            systemInstruction: getCoreSystemPrompt(''),
+            temperature: 0.0,
+            topP: 1,
+          },
+          contents,
+        });
+      });
+  
+      it('should override config temperature with provided generationConfig', async () => {
+        const contents = [{ role: 'user', parts: [{ text: 'test' }] }];
+        const configTemperature = 1.0;
+        const overrideTemperature = 0.5;
+        
+        // Mock config to return one temperature
+        vi.spyOn(client['config'], 'getTemperature').mockReturnValue(configTemperature);
+  
+        const mockGenerator: Partial<ContentGenerator> = {
+          countTokens: vi.fn().mockResolvedValue({ totalTokens: 1 }),
+          generateContent: mockGenerateContentFn,
+        };
+        client['contentGenerator'] = mockGenerator as ContentGenerator;
+  
+        // Pass temperature in generationConfig to override config
+        await client.generateContent(
+          contents,
+          { temperature: overrideTemperature },
+          new AbortController().signal
+        );
+  
+        expect(mockGenerateContentFn).toHaveBeenCalledWith({
+          model: 'test-model',
+          config: {
+            abortSignal: expect.any(AbortSignal),
+            systemInstruction: getCoreSystemPrompt(''),
+            temperature: overrideTemperature, // Should use override, not config
+            topP: 1,
+          },
+          contents,
+        });
+      });
+  
+      it('should use temperature from config in generateJson when no custom config provided', async () => {
+        const contents = [{ role: 'user', parts: [{ text: 'test' }] }];
+        const schema = { type: 'string' };
+        const customTemperature = 0.8;
+        
+        // Mock config to return custom temperature
+        vi.spyOn(client['config'], 'getTemperature').mockReturnValue(customTemperature);
+  
+        const mockGenerator: Partial<ContentGenerator> = {
+          countTokens: vi.fn().mockResolvedValue({ totalTokens: 1 }),
+          generateContent: mockGenerateContentFn,
+        };
+        client['contentGenerator'] = mockGenerator as ContentGenerator;
+  
+        await client.generateJson(contents, schema, new AbortController().signal);
+  
+        expect(mockGenerateContentFn).toHaveBeenCalledWith({
+          model: 'test-model',
+          config: {
+            abortSignal: expect.any(AbortSignal),
+            systemInstruction: getCoreSystemPrompt(''),
+            temperature: 0, // generateJson should still use 0 for deterministic output
+            topP: 1,
+            responseSchema: schema,
+            responseMimeType: 'application/json',
+          },
+          contents,
+        });
+      });
+  
+      it('should allow overriding temperature in generateJson with custom config', async () => {
+        const contents = [{ role: 'user', parts: [{ text: 'test' }] }];
+        const schema = { type: 'string' };
+        const configTemperature = 1.0;
+        const customTemperature = 0.3;
+        
+        // Mock config to return one temperature
+        vi.spyOn(client['config'], 'getTemperature').mockReturnValue(configTemperature);
+  
+        const mockGenerator: Partial<ContentGenerator> = {
+          countTokens: vi.fn().mockResolvedValue({ totalTokens: 1 }),
+          generateContent: mockGenerateContentFn,
+        };
+        client['contentGenerator'] = mockGenerator as ContentGenerator;
+  
+        await client.generateJson(
+          contents,
+          schema,
+          new AbortController().signal,
+          undefined, // use default model
+          { temperature: customTemperature }
+        );
+  
+        expect(mockGenerateContentFn).toHaveBeenCalledWith({
+          model: 'test-model',
+          config: {
+            abortSignal: expect.any(AbortSignal),
+            systemInstruction: getCoreSystemPrompt(''),
+            temperature: customTemperature, // Should use custom temperature
+            topP: 1,
+            responseSchema: schema,
+            responseMimeType: 'application/json',
+          },
+          contents,
+        });
+      });
     });
   });
 });

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -115,6 +115,12 @@ export class GeminiClient {
 
     this.embeddingModel = config.getEmbeddingModel();
     this.loopDetector = new LoopDetectionService(config);
+    
+    // Update generateContentConfig with temperature from config
+    this.generateContentConfig = {
+      temperature: config.getTemperature(),
+      topP: 1,
+    };
   }
 
   async initialize(contentGeneratorConfig: ContentGeneratorConfig) {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -429,7 +429,8 @@ export class GeminiClient {
       const requestConfig = {
         abortSignal,
         ...this.generateContentConfig,
-        ...config,
+        temperature: 0, // Default to 0 for deterministic JSON
+        ...config, // Still allow overrides
       };
 
       const apiCall = () =>


### PR DESCRIPTION
## TLDR

This PR adds a configurable temperature setting (0.0-2.0) to control response randomness in the Gemini CLI. Temperature can be set via CLI flag (`--temperature`/`-t`) or `settings.json`. The implementation ensures `generateJson` remains deterministic by defaulting to temperature 0, while regular content generation uses the configured temperature.

## Dive Deeper

### Key Changes
- Added `temperature` field to CLI arguments, settings, and core configuration
- Implemented proper validation with descriptive error messages for out-of-range values
- Updated `GeminiClient` to use temperature from configuration
- Fixed potential non-determinism in `generateJson` by explicitly defaulting to temperature 0
- Added comprehensive test coverage for all layers

### Technical Details
- **Configuration Precedence**: CLI args > settings.json > default (0.0)
- **Range**: 0.0 to 2.0 (following Gemini API specifications)
- **Default**: 0.0 (most deterministic behavior)
- **JSON Generation**: Always uses temperature 0 unless explicitly overridden

### Files Modified
- `packages/cli/src/config/config.ts` - CLI argument parsing and validation
- `packages/cli/src/config/settings.ts` - Settings interface
- `packages/core/src/config/config.ts` - Core configuration
- `packages/core/src/core/client.ts` - API integration with deterministic JSON fix
- Test files and documentation

## Reviewer Test Plan

1. **CLI Validation**:
   ```bash
   npm run start -- -t 0.5  # Valid temperature
   npm run start -- -t 6    # Should error: "Temperature must be between 0.0 and 2.0"
   ```

2. **Settings.json Configuration**:
   ```json
   {
     "temperature": 0.7
   }
   ```
   Then run `npm run start` and verify temperature is applied

3. **Interactive Testing**:
   - With temperature 0.0: Responses should be consistent/deterministic
   - With temperature 1.5: Responses should be more varied/creative
   - Test prompts: "Write a haiku about coding" (run multiple times)

4. **JSON Generation**:
   - Verify that tool calls remain deterministic regardless of temperature setting
   - Check that JSON responses are consistent across multiple runs

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

This PR addresses the need for configurable temperature control in the Gemini CLI to allow users to adjust response creativity/determinism based on their use case.